### PR TITLE
feat(homepage): Add brand storytelling section

### DIFF
--- a/packages/Webkul/Shop/src/Resources/views/checkout/cart/mini-cart.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/checkout/cart/mini-cart.blade.php
@@ -1,7 +1,7 @@
 <!-- Mini Cart Vue Component -->
 <v-mini-cart>
     <span
-        class="icon-cart cursor-pointer text-2xl text-zylver-olive-green"
+        class="icon-cart cursor-pointer text-2xl text-zylver-olive-green hover:text-zylver-gold"
         role="button"
         aria-label="@lang('shop::app.checkout.cart.mini-cart.shopping-cart')"
     ></span>
@@ -22,7 +22,7 @@
 
                     <span class="relative">
                         <span
-                            class="icon-cart cursor-pointer text-2xl text-zylver-olive-green"
+                            class="icon-cart cursor-pointer text-2xl text-zylver-olive-green hover:text-zylver-gold"
                             role="button"
                             aria-label="@lang('shop::app.checkout.cart.mini-cart.shopping-cart')"
                             tabindex="0"

--- a/packages/Webkul/Shop/src/Resources/views/components/home/brand-story.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/components/home/brand-story.blade.php
@@ -1,0 +1,48 @@
+<!-- Brand Storytelling Section -->
+<div class="bg-zylver-cream py-12 lg:py-16">
+    <div class="container mx-auto px-4">
+        <!-- Part 1: Our Heritage & Inspiration -->
+        <div class="flex flex-col lg:flex-row items-center mb-12 lg:mb-16">
+            <!-- Image Placeholder -->
+            <div class="w-full lg:w-1/2 mb-6 lg:mb-0 lg:pr-8">
+                <div class="bg-zylver-light-gold aspect-video w-full flex items-center justify-center">
+                    <p class="font-lato text-zylver-olive-green">Image Placeholder (Heritage)</p>
+                </div>
+            </div>
+            <!-- Text Content -->
+            <div class="w-full lg:w-1/2">
+                <h2 class="font-fraunces text-3xl lg:text-4xl text-zylver-olive-green mb-4">
+                    Rooted in Tradition, Crafted for Today
+                </h2>
+                <p class="font-lato text-base lg:text-lg text-zylver-text-primary leading-relaxed">
+                    ZYLVER is born from a deep reverence for India's timeless artistry. Each piece is a homage to centuries of craftsmanship, reimagined for the modern connoisseur who seeks not just jewelry, but a piece of heritage.
+                </p>
+            </div>
+        </div>
+        <!-- End Part 1 -->
+
+        <!-- Part 2: The ZYLVER Promise -->
+        <div class="flex flex-col lg:flex-row-reverse items-center"> <!-- Changed to flex-row-reverse for alternating layout -->
+            <!-- Image Placeholder -->
+            <div class="w-full lg:w-1/2 mb-6 lg:mb-0 lg:pl-8"> <!-- Added lg:pl-8 for spacing -->
+                <div class="bg-zylver-light-gold aspect-video w-full flex items-center justify-center">
+                    <p class="font-lato text-zylver-olive-green">Image Placeholder (Craftsmanship)</p>
+                </div>
+            </div>
+            <!-- Text Content -->
+            <div class="w-full lg:w-1/2">
+                <h2 class="font-fraunces text-3xl lg:text-4xl text-zylver-olive-green mb-4">
+                    Exquisite Craftsmanship, Enduring Beauty
+                </h2>
+                <p class="font-lato text-base lg:text-lg text-zylver-text-primary leading-relaxed mb-8">
+                    At ZYLVER, we believe in the alchemy of pure silver and masterful skill. Our artisans pour their passion into every curve and contour, creating not just adornments, but heirlooms that will illuminate your moments for generations to come.
+                </p>
+                <a href="{{ route('shop.shop.index') }}" class="inline-block bg-zylver-olive-green text-zylver-white font-lato py-3 px-8 rounded hover:bg-zylver-gold hover:text-zylver-olive-green transition-colors duration-300">
+                    Discover Our Collections
+                </a>
+            </div>
+        </div>
+        <!-- End Part 2 -->
+
+    </div>
+</div>

--- a/packages/Webkul/Shop/src/Resources/views/components/layouts/header/desktop/bottom.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/components/layouts/header/desktop/bottom.blade.php
@@ -109,7 +109,7 @@
                     aria-label="@lang('shop::app.components.layouts.header.desktop.bottom.compare')"
                 >
                     <span
-                        class="icon-compare inline-block cursor-pointer text-2xl"
+                        class="icon-compare inline-block cursor-pointer text-2xl text-zylver-olive-green hover:text-zylver-gold"
                         role="presentation"
                     ></span>
                 </a>
@@ -132,7 +132,7 @@
             <x-shop::dropdown position="bottom-{{ core()->getCurrentLocale()->direction === 'ltr' ? 'right' : 'left' }}">
                 <x-slot:toggle>
                     <span
-                        class="icon-users inline-block cursor-pointer text-2xl"
+                        class="icon-users inline-block cursor-pointer text-2xl text-zylver-olive-green hover:text-zylver-gold"
                         role="button"
                         aria-label="@lang('shop::app.components.layouts.header.desktop.bottom.profile')"
                         tabindex="0"

--- a/packages/Webkul/Shop/src/Resources/views/home/index.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/home/index.blade.php
@@ -43,6 +43,11 @@
 </div>
 <!-- End ZYLVER.IN Custom Hero Section -->
 
+    <!-- ZYLVER.IN Brand Storytelling Section -->
+    <x-shop::components.home.brand-story/>
+    <!-- End ZYLVER.IN Brand Storytelling Section -->
+
+
     <!-- Loop over the theme customization -->
     @foreach ($customizations as $customization)
         @php ($data = $customization->options) @endphp


### PR DESCRIPTION
This PR introduces the "The Essence of ZYLVER" brand storytelling section to the homepage, as per Phase 1.A of the ZYLVER.IN UI/UX overhaul.

**Changes:**
- Created a new Blade component `components.home.brand-story` for the section.
- Implemented two parts within the component:
    - "Our Heritage & Inspiration"
    - "The ZYLVER Promise"
- Styled using Tailwind CSS with Zylver brand colors (Olive Green, Gold, Cream) and fonts (Fraunces, Lato).
- Features responsive design with alternating image/text layout on desktop and stacked layout on mobile.
- Includes placeholder images and a "Discover Our Collections" call-to-action button.
- Integrated the new component into `home/index.blade.php` below the main hero section.

This section aims to enhance visitor engagement by sharing the brand's narrative and values.